### PR TITLE
Fix issue with HTML Panel, URL Field & Reflection Fields

### DIFF
--- a/fields/field.dynamictextgroup.php
+++ b/fields/field.dynamictextgroup.php
@@ -481,7 +481,7 @@
 	
 	
 		/* * * @see http://symphony-cms.com/learn/api/2.2/toolkit/field/#appendFormattedElement * * */
-		public function appendFormattedElement(&$wrapper, $data, $encode = false, $mode = null, $entry_id) {
+		public function appendFormattedElement(&$wrapper, $data, $encode = false, $mode = null, $entry_id = null) {
 			// Get field properties and decode schema
 			$fieldCount = $this->get('fieldcount');
 			$schema = json_decode($this->get('schema'));


### PR DESCRIPTION
After I save a field with Dynamci Text Group I was getting an error due to the `$entry_id` not being passed as a parameter. Setting a default value of null avoids this error.
