### PR TITLE
Fix 'required' checkbox

### DIFF
--- a/assets/dynamictextgroup.fieldeditor.js
+++ b/assets/dynamictextgroup.fieldeditor.js
@@ -65,7 +65,7 @@
 				field.label = $('.tfield', $(this)).val();
 				field.width = Math.round(dtgEditor.parseWidth($(this).innerWidth())*10)/10;
 				field.options = {};
-				field.options.required = $('input[name="required"]', $(this)).attr('checked');
+				field.options.required = $('input[name="required"]', $(this)).is(':checked');
 				field.options.type = $('#fieldType', $(this)).val();
 				//if (field.options.type == 'select') field.options.selectItems = $('#selectItems', $(this)).val();
 				if (field.options.type == 'select') {


### PR DESCRIPTION
I was in the middle of submitting an issue and looking for more information about the problem and ended up fixing it, see below.

Checking the 'required' checkbox in a field's flyout appears to have no effect (anymore?). I ran into this problem today so I updated to the latest commit on the development branch (was a couple of commits back on the same branch), but the problem persists. 

![image](https://f.cloud.github.com/assets/2836313/1299169/40e124c8-30fe-11e3-8204-1a53b6e07066.png)

When I select the flyout menu to make changes to the field type, I can make the change and it will save when I save the page (the flyout never hides again once it is open however). The 'required' checkbox, though, will not save its value. 

Per this question: http://stackoverflow.com/questions/901712/check-checkbox-checked-property-using-jquery - the right way to get the checked status of a checkbox is `.is(':checked')` - `.attr('checked')` was coming up `undefined` in Chrome (didn't test anywhere else...).

Side note, the flyout still never hides once it has been opened. Is that the intended behavior?
